### PR TITLE
Fixed Broken Link to Google Fonts API

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,8 +32,7 @@ License URL: http://creativecommons.org/licenses/by/3.0/
 	</script>
 	<!-- start-smoth-scrolling-->
 	<!--- webfonts -->
-	<link href='//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,300,600,700' rel='stylesheet'
-	 type='text/css'>
+	<link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@1,300;1,400;1,600;1,700&display=swap" rel="stylesheet">
 	<!--- webfonts -->
 	<!--start-top-nav-script-->
 	<script>


### PR DESCRIPTION
The link to google fonts to Open Sans font was broken and was not working. Updated it with the latest link to Open Sans fonts from google.